### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 1.0.0
+  current-version: 1.0.1
   next-version: 999-SNAPSHOT
 

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 1.0.1
+  current-version: 1.1.0
   next-version: 999-SNAPSHOT
 


### PR DESCRIPTION
This bumps the JGit dependency to 6.0.0.202111291000-r and quarkiverse-parent to 9