### PR TITLE
Release 2.2.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "2.1.0"
+  current-version: "2.2.0"
   next-version: "999-SNAPSHOT"
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.jgit</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
     <artifactId>quarkus-jgit-deployment</artifactId>
     <name>Quarkus - JGit - Deployment</name>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
-:quarkus-version: 2.10.2.Final
-:quarkus-jgit-version: 2.1.0
+:quarkus-version: 2.12.3.Final
+:quarkus-jgit-version: 2.2.0
 
 :quarkus-org-url: https://github.com/quarkusio
 :quarkus-base-url: {quarkus-org-url}/quarkus

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.jgit</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.jgit</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
     <artifactId>quarkus-jgit-integration-tests</artifactId>
     <name>Quarkus - JGit - Integration Tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>io.quarkiverse.jgit</groupId>
     <artifactId>quarkus-jgit-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
     <name>Quarkus - JGit - Parent</name>
     <modules>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.jgit</groupId>
         <artifactId>quarkus-jgit-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
     <artifactId>quarkus-jgit</artifactId>
     <name>Quarkus - JGit - Runtime</name>


### PR DESCRIPTION
# What

The new version 6.3.0 of JGit comes with a new feature which is shallow cloning (as described [here](https://projects.eclipse.org/projects/technology.jgit/releases/6.3.0)) which would be very appreciated by our team.

# Why

Usually we would just bypass this extension, waiting for the release. But it happens that without the configuration in this repository, it is very challenging to make JGit works in native packaging (thanks for the work by the way).

# How

I mimicked the way you did the previous version. The dependabot already came up with the new version of JGit, all that was left was to make a release.