### PR TITLE
Produce build item with gitea service info

### DIFF
--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
@@ -62,7 +62,7 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
                 "--must-change-password=false",
                 "--admin"
         };
-        log.info(String.join(" ", cmd));
+        log.debug(String.join(" ", cmd));
         ExecResult execResult = execInContainer(cmd);
         log.info(execResult.getStdout());
         if (execResult.getExitCode() != 0) {

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
@@ -71,6 +71,10 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
     }
 
     public String getHttpUrl() {
-        return "http://" + getHost() + ":" + getMappedPort(HTTP_PORT);
+        return "http://" + getHost() + ":" + getHttpPort();
+    }
+
+    public int getHttpPort() {
+        return getMappedPort(HTTP_PORT);
     }
 }

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
@@ -2,34 +2,37 @@ package io.quarkus.jgit.deployment;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * A build item that represents the information required to connect to a Gitea dev service.
+ */
 public final class GiteaDevServiceInfoBuildItem extends SimpleBuildItem {
 
-    private final String url;
     private final String host;
-    private final String username;
-    private final String password;
+    private final int httpPort;
+    private final String adminUsername;
+    private final String adminPassword;
 
-    public GiteaDevServiceInfoBuildItem(String url, String host, String username, String password) {
-        this.url = url;
+    public GiteaDevServiceInfoBuildItem(String host, int httpPort, String adminUsername, String adminPassword) {
         this.host = host;
-        this.username = username;
-        this.password = password;
+        this.httpPort = httpPort;
+        this.adminUsername = adminUsername;
+        this.adminPassword = adminPassword;
     }
 
-    public String getUrl() {
-        return url;
+    public int httpPort() {
+        return httpPort;
     }
 
-    public String getHost() {
+    public String host() {
         return host;
     }
 
-    public String getUsername() {
-        return username;
+    public String adminUsername() {
+        return adminUsername;
     }
 
-    public String getPassword() {
-        return password;
+    public String adminPassword() {
+        return adminPassword;
     }
 
 }

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
@@ -1,0 +1,35 @@
+package io.quarkus.jgit.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class GiteaDevServiceInfoBuildItem extends SimpleBuildItem {
+
+    private final String url;
+    private final String host;
+    private final String username;
+    private final String password;
+
+    public GiteaDevServiceInfoBuildItem(String url, String host, String username, String password) {
+        this.url = url;
+        this.host = host;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
@@ -6,6 +6,7 @@ import java.util.function.BooleanSupplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
@@ -20,7 +21,8 @@ public class JGitDevServicesProcessor {
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class, DevServicesEnabled.class })
     DevServicesResultBuildItem createContainer(JGitBuildTimeConfig config,
-            CuratedApplicationShutdownBuildItem closeBuildItem) {
+            CuratedApplicationShutdownBuildItem closeBuildItem,
+            BuildProducer<GiteaDevServiceInfoBuildItem> giteaServiceInfo) {
         if (devService != null) {
             // only produce DevServicesResultBuildItem when the dev service first starts.
             return null;
@@ -34,6 +36,8 @@ public class JGitDevServicesProcessor {
         ContainerShutdownCloseable closeable = new ContainerShutdownCloseable(gitServer, JGitProcessor.FEATURE);
         closeBuildItem.addCloseTask(closeable::close, true);
         devService = new RunningDevService(JGitProcessor.FEATURE, gitServer.getContainerId(), closeable, configOverrides);
+
+        giteaServiceInfo.produce(new GiteaDevServiceInfoBuildItem(httpUrl, gitServer.getHost(), config.devservices().adminUsername(), config.devservices().adminPassword()));
         return devService.toBuildItem();
     }
 

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
@@ -37,7 +37,12 @@ public class JGitDevServicesProcessor {
         closeBuildItem.addCloseTask(closeable::close, true);
         devService = new RunningDevService(JGitProcessor.FEATURE, gitServer.getContainerId(), closeable, configOverrides);
 
-        giteaServiceInfo.produce(new GiteaDevServiceInfoBuildItem(httpUrl, gitServer.getHost(), config.devservices().adminUsername(), config.devservices().adminPassword()));
+        giteaServiceInfo.produce(
+                new GiteaDevServiceInfoBuildItem(
+                        gitServer.getHost(),
+                        gitServer.getHttpPort(),
+                        config.devservices().adminUsername(),
+                        config.devservices().adminPassword()));
         return devService.toBuildItem();
     }
 


### PR DESCRIPTION
The pull request generates a build item that can be consumed by other processors or devservices.

The main reason I am using this vs config overrides is ordering, which can't be guaranteed by overrides.
As I am interersted in service to service integration, ordering is important.