### PR TITLE
Allow repository creation in the Gitea DevService

### DIFF
--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
@@ -4,6 +4,7 @@ import static org.testcontainers.containers.wait.strategy.Wait.forListeningPorts
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.jboss.logging.Logger;
@@ -43,7 +44,7 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
         if (!reused) {
             try {
                 createAdminUser();
-                for (String repository : devServiceConfig.repositories()) {
+                for (String repository : devServiceConfig.repositories().orElse(Collections.emptyList())) {
                     createRepository(this, repository);
                 }
             } catch (IOException | InterruptedException e) {

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaContainer.java
@@ -3,6 +3,8 @@ package io.quarkus.jgit.deployment;
 import static org.testcontainers.containers.wait.strategy.Wait.forListeningPorts;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
@@ -15,10 +17,10 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
      * Logger which will be used to capture container STDOUT and STDERR.
      */
     private static final Logger log = Logger.getLogger(GiteaContainer.class);
-
     private static final int HTTP_PORT = 3000;
 
     private JGitBuildTimeConfig.DevService devServiceConfig;
+    private List<String> repositories = new ArrayList<>();
 
     GiteaContainer(JGitBuildTimeConfig.DevService devServiceConfig) {
         super("gitea/gitea:latest-rootless");
@@ -41,6 +43,9 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
         if (!reused) {
             try {
                 createAdminUser();
+                for (String repository : devServiceConfig.repositories()) {
+                    createRepository(this, repository);
+                }
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Failed to create admin user", e);
             }
@@ -70,11 +75,46 @@ class GiteaContainer extends GenericContainer<GiteaContainer> {
         }
     }
 
+    private void createRepository(GiteaContainer giteaContainer, String repository)
+            throws UnsupportedOperationException, IOException, InterruptedException {
+        String httpUrl = "http://localhost:" + GiteaContainer.HTTP_PORT;
+        String data = """
+                {"name":"%s", "private":false, "auto_init":true, "readme":"Default"}
+                """
+                .formatted(repository);
+
+        String[] cmd = {
+                "/usr/bin/curl",
+                "-X",
+                "POST",
+                "--user",
+                devServiceConfig.adminUsername() + ":" + devServiceConfig.adminPassword(),
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                data,
+                httpUrl + "/api/v1/user/repos"
+        };
+
+        log.debug(String.join(" ", cmd));
+        ExecResult execResult = giteaContainer.execInContainer(cmd);
+        log.info(execResult.getStdout());
+        if (execResult.getExitCode() != 0) {
+            throw new RuntimeException("Failed to create repository: " + repository + ":" + execResult.getStderr());
+        }
+        repositories.add(repository);
+        log.info("Created repository: " + repository);
+    }
+
     public String getHttpUrl() {
         return "http://" + getHost() + ":" + getHttpPort();
     }
 
     public int getHttpPort() {
         return getMappedPort(HTTP_PORT);
+    }
+
+    public List<String> getRepositories() {
+        return repositories;
     }
 }

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/GiteaDevServiceInfoBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.jgit.deployment;
 
+import java.util.List;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
@@ -11,12 +13,15 @@ public final class GiteaDevServiceInfoBuildItem extends SimpleBuildItem {
     private final int httpPort;
     private final String adminUsername;
     private final String adminPassword;
+    private final List<String> repositories;
 
-    public GiteaDevServiceInfoBuildItem(String host, int httpPort, String adminUsername, String adminPassword) {
+    public GiteaDevServiceInfoBuildItem(String host, int httpPort, String adminUsername, String adminPassword,
+            List<String> repositories) {
         this.host = host;
         this.httpPort = httpPort;
         this.adminUsername = adminUsername;
         this.adminPassword = adminPassword;
+        this.repositories = repositories;
     }
 
     public int httpPort() {
@@ -35,4 +40,7 @@ public final class GiteaDevServiceInfoBuildItem extends SimpleBuildItem {
         return adminPassword;
     }
 
+    public List<String> repositories() {
+        return repositories;
+    }
 }

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.jgit.deployment;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -51,7 +52,7 @@ public interface JGitBuildTimeConfig {
          * Repositories to be created when the Dev Service starts.
          */
         @WithDefault("${quarkus.application.name}")
-        List<String> repositories();
+        Optional<List<String>> repositories();
 
         /**
          * Should the container be reused?

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.jgit.deployment;
 
+import java.util.List;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -45,6 +46,12 @@ public interface JGitBuildTimeConfig {
          */
         @WithDefault("quarkus")
         String adminPassword();
+
+        /**
+         * Repositories to be created when the Dev Service starts.
+         */
+        @WithDefault("${quarkus.application.name}")
+        List<String> repositories();
 
         /**
          * Should the container be reused?

--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
@@ -41,7 +41,8 @@ public class JGitDevServicesProcessor {
                 gitServer.getHost(),
                 gitServer.getHttpPort(),
                 config.devservices().adminUsername(),
-                config.devservices().adminPassword()));
+                config.devservices().adminPassword(),
+                gitServer.getRepositories()));
         return devService.toBuildItem();
     }
 

--- a/docs/modules/ROOT/pages/includes/quarkus-jgit.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jgit.adoc
@@ -93,6 +93,23 @@ endif::add-copy-button-to-env-var[]
 |string
 |`quarkus`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-jgit_quarkus-jgit-devservices-repositories]] [.property-path]##link:#quarkus-jgit_quarkus-jgit-devservices-repositories[`quarkus.jgit.devservices.repositories`]##
+
+[.description]
+--
+Repositories to be created when the Dev Service starts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_JGIT_DEVSERVICES_REPOSITORIES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_JGIT_DEVSERVICES_REPOSITORIES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`${quarkus.application.name}`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-jgit_quarkus-jgit-devservices-reuse]] [.property-path]##link:#quarkus-jgit_quarkus-jgit-devservices-reuse[`quarkus.jgit.devservices.reuse`]##
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-jgit_quarkus.jgit.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jgit_quarkus.jgit.adoc
@@ -93,6 +93,23 @@ endif::add-copy-button-to-env-var[]
 |string
 |`quarkus`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-jgit_quarkus-jgit-devservices-repositories]] [.property-path]##link:#quarkus-jgit_quarkus-jgit-devservices-repositories[`quarkus.jgit.devservices.repositories`]##
+
+[.description]
+--
+Repositories to be created when the Dev Service starts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_JGIT_DEVSERVICES_REPOSITORIES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_JGIT_DEVSERVICES_REPOSITORIES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`${quarkus.application.name}`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-jgit_quarkus-jgit-devservices-reuse]] [.property-path]##link:#quarkus-jgit_quarkus-jgit-devservices-reuse[`quarkus.jgit.devservices.reuse`]##
 
 [.description]

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.native.resources.includes=repos/**
 quarkus.jgit.devservices.enabled=true
 quarkus.jgit.devservices.http-port=8089
-quarkus.jgit.devservices.show-logs=true
+quarkus.jgit.devservices.show-logs=false
 quarkus.jgit.devservices.repositories=${quarkus.application.name},extra-repo1,extra-repo2

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -2,3 +2,4 @@ quarkus.native.resources.includes=repos/**
 quarkus.jgit.devservices.enabled=true
 quarkus.jgit.devservices.http-port=8089
 quarkus.jgit.devservices.show-logs=true
+quarkus.jgit.devservices.repositories=${quarkus.application.name},extra-repo1,extra-repo2

--- a/integration-tests/src/test/java/io/quarkus/it/jgit/DevServiceTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/jgit/DevServiceTest.java
@@ -16,6 +16,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.gitea.ApiClient;
 import io.gitea.Configuration;
@@ -63,10 +65,16 @@ public class DevServiceTest {
                 .statusCode(200);
     }
 
-    @Test
-    public void shouldCloneFromDevService(@TempDir Path tempDir) throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "test-repo", // The repository created in the @BeforeAll method
+            "quarkus-jgit-integration-tests", //The project repository created by the Dev Service
+            "extra-repo1", // An extra repository created by the Dev Service
+            "extra-repo2" // An other extra repository created by the Dev Service
+    })
+    public void shouldCloneFromDevService(String repositoryName, @TempDir Path tempDir) throws Exception {
         try (Git git = Git.cloneRepository().setDirectory(tempDir.toFile())
-                .setURI(config.devservices().httpUrl().get() + "/quarkus/test-repo.git").call()) {
+                .setURI(config.devservices().httpUrl().get() + "/quarkus/" + repositoryName + ".git").call()) {
             assertThat(tempDir.resolve("README.md")).isRegularFile();
             assertThat(git.log().call()).extracting(RevCommit::getFullMessage).map(String::trim).contains("Initial commit");
         }


### PR DESCRIPTION
Unfortunately, it's not possible to get repositories in gitea autocreated. This means that people have to use the Gitea API in order to create repositories before they use them with jgit. 

I would prefer if users of this feature could get the repositories pre-created and not deal with gitea clients. This pull request does exactly that. More specifically:

- Introduces `quarkus.jgit.project-repository.enabled` that enables the creation of a repo named after the project.
- Introduces `quarkus.jgit.extra-repositories` that enables creation of additional repositories.
- Adds the created repos in the build item produced by the Dev Service.
- Adds tests for both.
