### PR TITLE
Register org.eclipse.jgit.lib.GpgConfig$GpgFormat for reflection

### DIFF
--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitProcessor.java
@@ -6,6 +6,7 @@ import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.internal.JGitText;
 import org.eclipse.jgit.lib.CommitConfig;
 import org.eclipse.jgit.lib.CoreConfig;
+import org.eclipse.jgit.lib.GpgConfig;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -47,7 +48,8 @@ class JGitProcessor {
                 CoreConfig.SymLinks.class,
                 CoreConfig.LogRefUpdates.class,
                 CoreConfig.TrustStat.class,
-                DirCache.DirCacheVersion.class).fields().methods().build();
+                DirCache.DirCacheVersion.class,
+                GpgConfig.GpgFormat.class).fields().methods().build();
     }
 
     @BuildStep

--- a/integration-tests/src/test/java/io/quarkus/it/jgit/JGitTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/jgit/JGitTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.jgit;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.core.Is.is;
 
 import org.eclipse.jgit.storage.file.FileBasedConfig;
@@ -37,4 +38,13 @@ public class JGitTest {
                 .body(is("true"));
     }
 
+    @Test
+    void shouldCommit() {
+        given().body("Test commit")
+                .post("/jgit/commit")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body(matchesRegex("^[a-f0-9]{40}$"));
+    }
 }


### PR DESCRIPTION
Fixes a native mode issue encountered with Camel Quarkus and quarkus-jgit 3.4.0.

```
Caused by: java.lang.IllegalArgumentException: Enumerated values of type org.eclipse.jgit.lib.GpgConfig$GpgFormat not available
	at org.eclipse.jgit.lib.Config.allValuesOf(Config.java:585)
	at org.eclipse.jgit.lib.Config.getEnum(Config.java:572)
	at org.eclipse.jgit.lib.GpgConfig.<init>(GpgConfig.java:77)
	at org.eclipse.jgit.api.CommitCommand.processOptions(CommitCommand.java:652)
	at org.eclipse.jgit.api.CommitCommand.call(CommitCommand.java:187)
	at org.apache.camel.component.git.producer.GitProducer.doCommit(GitProducer.java:340)
	at org.apache.camel.component.git.producer.GitProducer.process(GitProducer.java:125)
	at org.apache.camel.support.AsyncProcessorConverterHelper$ProcessorToAsyncProcessorBridge.process(AsyncProcessorConverterHelper.java:65)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.processNonTransacted(SharedCamelInternalProcessor.java:156)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:133)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor$1.process(SharedCamelInternalProcessor.java:89)
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:82)
	at org.apache.camel.impl.engine.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86)
	at org.apache.camel.support.cache.DefaultProducerCache.send(DefaultProducerCache.java:178)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:175)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:171)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.send(DefaultProducerTemplate.java:157)
	at org.apache.camel.impl.engine.DefaultProducerTemplate.sendBodyAndHeader(DefaultProducerTemplate.java:228)
	... 35 more
Caused by: java.lang.NoSuchMethodException: org.eclipse.jgit.lib.GpgConfig$GpgFormat.values()
	at java.base@21.0.2/java.lang.Class.checkMethod(DynamicHub.java:1075)
	at java.base@21.0.2/java.lang.Class.getMethod(DynamicHub.java:1060)
	at org.eclipse.jgit.lib.Config.allValuesOf(Config.java:580)
```