### PR TITLE
Flatten modules when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
+.flattened-pom.xml

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -8,6 +8,7 @@
     </parent>
     <artifactId>quarkus-jgit-deployment</artifactId>
     <name>Quarkus - JGit - Deployment</name>
+    <description>Quarkus - JGit - Deployment</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </build>
     <profiles>
         <profile>
-            <id>docs</id>
+            <id>unreleased-modules</id>
             <activation>
                 <property>
                     <name>performRelease</name>
@@ -94,19 +94,47 @@
             </activation>
             <modules>
                 <module>docs</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>it</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <modules>
                 <module>integration-tests</module>
             </modules>
         </profile>
+        <profile>
+            <id>flatten-poms</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                                <configuration>
+                                    <flattenMode>ossrh</flattenMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
+
 </project>


### PR DESCRIPTION
- Update Maven project structure to support OSSRH compliance and improve release management.
- Refactor project profiles (`unreleased-modules` and `flatten-poms`) to enhance build configuration and modularity.
- Add `.flattened-pom.xml` to `.gitignore` to streamline artifact handling.
