### PR TITLE
Introduce quarkus-jgit-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse</groupId>
@@ -81,6 +82,41 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>io.sundr</groupId>
+                <artifactId>sundr-maven-plugin</artifactId>
+                <version>0.200.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-bom</goal>
+                        </goals>
+                        <configuration>
+                            <boms>
+                                <bom>
+                                    <artifactId>quarkus-jgit-bom</artifactId>
+                                    <name>Quarkus JGit: BOM</name>
+                                    <description>Centralized dependencyManagement for the Quarkus JGit Project
+                                    </description>
+                                    <dependencies>
+                                        <includes>
+                                            <include>org.eclipse.jgit:*</include>
+                                        </includes>
+                                    </dependencies>
+                                    <modules>
+                                        <excludes>
+                                            <exclude>io.quarkiverse.jgit:quarkus-jgit-docs</exclude>
+                                            <exclude>io.quarkiverse.jgit:quarkus-jgit-integration-tests</exclude>
+                                        </excludes>
+                                    </modules>
+                                </bom>
+                            </boms>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>


### PR DESCRIPTION
- Fixes #191

It generates a BOM like the following: 
```xml
<?xml version='1.0' encoding='UTF-8'?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>io.quarkiverse.jgit</groupId>
    <artifactId>quarkus-jgit-bom</artifactId>
    <version>999-SNAPSHOT</version>
    <name>Quarkus JGit: BOM</name>
    <packaging>pom</packaging>
    <description>Centralized dependencyManagement for the Quarkus JGit Project</description>

    <url>https://quarkiverse.io</url>
    <licenses>
        <license>
            <name>Apache License, Version 2.0</name>
            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
            <distribution>repo</distribution>
        </license>
    </licenses>


    <scm>
        <connection>scm:git:git@github.com:quarkiverse/quarkus-jgit.git</connection>
        <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-jgit.git</developerConnection>
        <url>https://github.com/quarkiverse/quarkus-jgit</url>
        <tag>HEAD</tag>
    </scm>

    <developers>
        <developer>
            <id>quarkus</id>
            <name>Quarkus Community</name>
        </developer>
    </developers>
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>io.quarkiverse.jgit</groupId>
                <artifactId>quarkus-jgit</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.jgit</groupId>
                <artifactId>quarkus-jgit-deployment</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>org.eclipse.jgit</groupId>
                <artifactId>org.eclipse.jgit</artifactId>
                <version>7.2.0.202503040940-r</version>
            </dependency>
            <dependency>
                <groupId>org.eclipse.jgit</groupId>
                <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
                <version>7.2.0.202503040940-r</version>
            </dependency>
        </dependencies>
    </dependencyManagement>
</project>
```
