### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitDevServicesProcessor.java
@@ -12,7 +12,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 
 public class JGitDevServicesProcessor {
@@ -20,7 +20,7 @@ public class JGitDevServicesProcessor {
     private static final Logger log = Logger.getLogger(JGitDevServicesProcessor.class);
     static volatile RunningDevService devService;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { DevServicesConfig.Enabled.class })
     DevServicesResultBuildItem createContainer(JGitBuildTimeConfig config,
             Optional<GiteaDevServiceRequestBuildItem> devServiceRequest,
             CuratedApplicationShutdownBuildItem closeBuildItem,

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.15.1
+:quarkus-version: 3.20.0
 :quarkus-jgit-version: 3.5.2
 :project-version: 3.5.2
 :examples-dir: ./../examples/

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <module>runtime</module>
     </modules>
     <properties>
-        <quarkus.version>3.15.1</quarkus.version>
+        <quarkus.version>3.20.0</quarkus.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>
         <quarkus-jsch.version>3.0.15</quarkus-jsch.version>
     </properties>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped soon.

> [!WARNING]
> This PR also sets the minimal version of Quarkus to 3.20.0. I think it's something acceptable so late in the 3.15 cycle?