### PR TITLE
Add Git LFS support

### DIFF
--- a/deployment/src/main/java/io/quarkus/jgit/deployment/JGitLfsProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jgit/deployment/JGitLfsProcessor.java
@@ -1,0 +1,49 @@
+package io.quarkus.jgit.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.jgit.runtime.JGitLfsRecorder;
+
+@BuildSteps(onlyIf = JGitLfsProcessor.IsLfsAvailable.class)
+class JGitLfsProcessor {
+
+    static class IsLfsAvailable implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return QuarkusClassLoader.isClassPresentAtRuntime("org.eclipse.jgit.lfs.BuiltinLFS");
+        }
+    }
+
+    @BuildStep
+    void registerLfsClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            BuildProducer<NativeImageResourceBundleBuildItem> resourceBundles) {
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder("org.eclipse.jgit.lfs.BuiltinLFS")
+                .methods().build());
+        // LfsText and Protocol inner classes need field access for NLS and Gson serialization respectively
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "org.eclipse.jgit.lfs.internal.LfsText",
+                "org.eclipse.jgit.lfs.Protocol$Request",
+                "org.eclipse.jgit.lfs.Protocol$Response",
+                "org.eclipse.jgit.lfs.Protocol$ObjectSpec",
+                "org.eclipse.jgit.lfs.Protocol$ObjectInfo",
+                "org.eclipse.jgit.lfs.Protocol$Action",
+                "org.eclipse.jgit.lfs.Protocol$ExpiringAction",
+                "org.eclipse.jgit.lfs.Protocol$Error")
+                .fields().methods().build());
+        resourceBundles.produce(new NativeImageResourceBundleBuildItem("org.eclipse.jgit.lfs.internal.LfsText"));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void registerBuiltinLfs(JGitLfsRecorder recorder) {
+        recorder.registerBuiltinLfs();
+    }
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -14,14 +14,26 @@ Once you have your Quarkus project configured you can add the `jgit` extension t
 ./mvnw quarkus:add-extension -Dextensions="jgit"
 ----
 
-This will add the following to your `pom.xml`:
+First, add the `quarkus-jgit-bom` to your project's `<dependencyManagement>` section to ensure version alignment of all JGit dependencies:
 
 [source,xml,subs=attributes+]
 ----
 <dependency>
     <groupId>io.quarkiverse.jgit</groupId>
-    <artifactId>quarkus-jgit</artifactId>
+    <artifactId>quarkus-jgit-bom</artifactId>
     <version>{quarkus-jgit-version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+</dependency>
+----
+
+Then add the extension dependency without specifying a version:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkiverse.jgit</groupId>
+    <artifactId>quarkus-jgit</artifactId>
 </dependency>
 ----
 
@@ -47,6 +59,24 @@ Here is an example using it in a JAX-RS endpoint:
 ====
 When building a native executable, make sure that the link:{quarkus-guides-url}/native-and-ssl#the-truststore-path[SSL support is configured appropriately].
 ====
+
+== Git LFS Support
+
+https://git-lfs.com/[Git Large File Storage (LFS)] is a Git extension that replaces large files (such as binaries, media assets, and datasets) with lightweight pointers in the repository, while storing the actual file contents on a remote server.
+
+The extension automatically detects the presence of the JGit LFS module on the classpath and registers the necessary classes for native image compilation.
+
+To enable Git LFS support, add the following dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.eclipse.jgit</groupId>
+    <artifactId>org.eclipse.jgit.lfs</artifactId>
+</dependency>
+----
+
+No additional configuration is required.
 
 == DevServices
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -14,6 +14,10 @@
             <artifactId>quarkus-jgit</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.lfs</artifactId>
+        </dependency>
 
         <!-- JAX-RS -->
         <dependency>

--- a/integration-tests/src/main/java/io/quarkus/it/jgit/JGitResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/jgit/JGitResource.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.internal.storage.file.WindowCache;
+import org.eclipse.jgit.lfs.internal.LfsText;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -109,6 +110,13 @@ public class JGitResource {
                     .call();
             return commit.getId().getName();
         }
+    }
+
+    @GET
+    @Path("/lfs/nls")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String lfsNls() {
+        return LfsText.get().repositoryNotFound;
     }
 
     private AbstractTreeIterator prepareTreeParser(Repository repository, RevCommit commit) throws IOException {

--- a/integration-tests/src/test/java/io/quarkus/it/jgit/JGitTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/jgit/JGitTest.java
@@ -39,6 +39,13 @@ public class JGitTest {
     }
 
     @Test
+    void shouldLoadLfsNls() {
+        given().get("/jgit/lfs/nls").then()
+                .statusCode(200)
+                .body(is("Repository {0} not found"));
+    }
+
+    @Test
     void shouldCommit() {
         given().body("Test commit")
                 .post("/jgit/commit")

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit.lfs</artifactId>
+                <version>${jgit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
                 <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
                 <version>${jgit.version}</version>
                 <exclusions>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.lfs</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>

--- a/runtime/src/main/java/io/quarkus/jgit/runtime/JGitLfsRecorder.java
+++ b/runtime/src/main/java/io/quarkus/jgit/runtime/JGitLfsRecorder.java
@@ -1,0 +1,13 @@
+package io.quarkus.jgit.runtime;
+
+import org.eclipse.jgit.lfs.BuiltinLFS;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class JGitLfsRecorder {
+
+    public void registerBuiltinLfs() {
+        BuiltinLFS.register();
+    }
+}


### PR DESCRIPTION
## Summary
- Add optional `org.eclipse.jgit.lfs` support for native image compilation
- Register `LfsText` for reflection and resource bundles when LFS is detected on the classpath
- Call `BuiltinLFS.register()` at static init time to activate smudge/clean filters
- Add `org.eclipse.jgit.lfs` to dependency management in root POM and BOM
- Update documentation to recommend using `quarkus-jgit-bom` for version alignment

## Test plan
- [x] Integration test verifies LFS NLS bundle loads correctly (`/jgit/lfs/nls` endpoint)
- [x] `NativeJGitIT` extends `JGitTest`, so the LFS test runs in native mode as well
- [ ] Verify native image build with a project that uses LFS clone operations

Closes #240