### PR TITLE
Split build workflow into JVM and Native jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,22 +35,17 @@ defaults:
     shell: bash
 
 jobs:
-  build:
-    name: Build on ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-#        os: [windows-latest, macos-latest, ubuntu-latest]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  jvm:
+    name: JVM Build
+    runs-on: ubuntu-latest
     steps:
       - name: Prepare git
         run: git config --global core.autocrlf false
         if: startsWith(matrix.os, 'windows')
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -58,6 +53,23 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B clean install -Dno-format
+
+  native:
+    name: Native Build
+    needs: jvm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare git
+        run: git config --global core.autocrlf false
+        if: startsWith(matrix.os, 'windows')
+
+      - uses: actions/checkout@v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: 'maven'
 
       - name: Build with Maven (Native)
         run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip


### PR DESCRIPTION
## Summary
- Separate JVM and Native builds into independent jobs so they run in parallel after JVM succeeds
- Native job depends on JVM job passing first
- Update actions/checkout from v4 to v7
- Update actions/setup-java from v4 to v5